### PR TITLE
add ability to show source code file description to users

### DIFF
--- a/rootthebox.py
+++ b/rootthebox.py
@@ -832,6 +832,14 @@ define(
 )
 
 define(
+    "show_source_code_description",
+    default=False,
+    group="game",
+    help="show description of a source code file to users",
+    type=bool,
+)
+
+define(
     "password_upgrade_cost",
     default=1000,
     group="game",

--- a/templates/upgrades/source_code_market.html
+++ b/templates/upgrades/source_code_market.html
@@ -62,6 +62,9 @@
                             <th>{{ _("Level") }}</th>
                             <th>{% if options.banking %}{{ _("Price") }}{% else %}{{ _("Cost") }}{% end %}</th>
                             <th>{{ _("File Name") }}</th>
+							{% if options.show_source_code_description %}
+								<th>{{ _("File Description") }}</th>
+							{% end %}
                             <th>{{ _("Checksum") }}</th>
                             <th><!-- Buy/Download --></th>
                         </tr>
@@ -78,6 +81,9 @@
                                 {% else %}
                                     <td>{{ box.source_code.file_name[:25] + "..." }}</td>
                                 {% end %}
+								{% if options.show_source_code_description %}
+									<td>{{ box.source_code.description }}</td>
+								{% end %}
                                 <td>{{ box.source_code.checksum }}</td>
                                 {% if box.source_code in user.team.purchased_source_code %}
                                     <td>


### PR DESCRIPTION
add new config key show_source_code_description to allow dispalying the source code file description to the user